### PR TITLE
Install guide: Change Fabric API link to 1.19 version

### DIFF
--- a/installation/fabric_mods_install.md
+++ b/installation/fabric_mods_install.md
@@ -3,7 +3,7 @@ In this tutorial, we will install the Fabric launcher and 5 mods. Remember to us
 1. You can download the latest Fabric Installer from [here](https://fabricmc.net/use/installer/). For Windows users, just download the `.exe` file. For Mac or Ubuntu users, download the jar file and call `java -jar fabric-installer-0.11.2.jar` to install. Select game version to be `1.19` and loader version to be `0.14.18`. It will automatically detect your Minecraft game install location.
 2. After installing Fabric, you will have a `YOUR_MINECRAFT_GAME_LOCATION/mod` folder. You need to put all the mods under this folder. Also, you will have a `YOUR_MINECRAFT_GAME_LOCATION/versions/fabric-loader-0.14.18-1.19`. This is the version you will run the game with. 
 3. Here are 4 mods that can be directly downloaded to `YOUR_MINECRAFT_GAME_LOCATION/mod` folder: 
-   * [Fabric API](https://modrinth.com/mod/fabric-api): Basic Fabric APIs.
+   * [Fabric API](https://modrinth.com/mod/fabric-api/version/0.58.0+1.19): Basic Fabric APIs.
    * [Mod Menu](https://cdn.modrinth.com/data/mOgUt4GM/versions/4.0.4/modmenu-4.0.4.jar): Used to manage all the mods that you download.
    * [Complete Config](https://www.curseforge.com/minecraft/mc-mods/completeconfig/download/3821056): Dependency of server pause.
    * [Multi Server Pause](https://www.curseforge.com/minecraft/mc-mods/multiplayer-server-pause-fabric/download/3822586): Used to pause the server when waiting for GPT-4 to reply.


### PR DESCRIPTION
Very easy to install the wrong version. This links to the specific version (1.19) that the rest of the guide uses.