### PR TITLE
build: read file using utf-8 explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ EXTRAS = {}
 def _read_file(fname):
     # this_dir = os.path.abspath(os.path.dirname(__file__))
     # with open(os.path.join(this_dir, fname)) as f:
-    with pathlib.Path(fname).open() as fp:
+    with pathlib.Path(fname).open(encoding="utf-8") as fp:
         return fp.read()
 
 


### PR DESCRIPTION
fixing `pip install -e .` error at windows:

```
(voyager-venv) D:\workspace\Voyager [main ≡]> pip install -e .
Obtaining file:///D:/workspace/Voyager
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.      
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "D:\workspace\Voyager\setup.py", line 38, in <module>
          long_description=_read_file("README.md"),
        File "D:\workspace\Voyager\setup.py", line 16, in _read_file
          return fp.read()
      UnicodeDecodeError: 'gbk' codec can't decode byte 0xa5 in position 2191: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```