### PR TITLE
Update requirements.txt - New chromadb version does not work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ setuptools
 openai
 chardet
 cchardet
-chromadb
+chromadb==0.3.29
 tiktoken
 requests
 setuptools


### PR DESCRIPTION
Recently the 0.4 version of chromadb has been released (https://pypi.org/project/chromadb/#history). When running the code with the last version it raises an error. However, installing the 0.3.29 version solves the error.