### PR TITLE
fixing version | new version of prismarine-block is incompatible

### DIFF
--- a/voyager/env/mineflayer/package.json
+++ b/voyager/env/mineflayer/package.json
@@ -22,7 +22,7 @@
         "mineflayer-tool": "^1.2.0",
         "mocha": "^10.2.0",
         "prismarine-biome": "^1.3.0",
-        "prismarine-block": "^1.16.3",
+        "prismarine-block": "=1.16.3",
         "prismarine-entity": "^2.2.0",
         "prismarine-item": "^1.12.1",
         "prismarine-nbt": "^2.2.1",


### PR DESCRIPTION
Currently the setup instructions are fixed to version 1.9 of Minecraft. Some packages are drifting. When running the [Node.js install steps](https://github.com/MineDojo/Voyager#nodejs-install) `npx tsc` fails to succeed since a package has changed its api. See issue [112](https://github.com/MineDojo/Voyager/issues/112) for details and others effected.

The proposed solution is to fix the version
replacing "prismarine-block": "^1.16.3" with "prismarine-block": "=1.16.3"

## Current behavior
error when running `npc tsc`

## Desired behavior
successful compilation 