### PR TITLE
Add additional installation step to readme to fix version missmatch fixes #120

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cd voyager/env/mineflayer
 npm install -g npx
 npm install
 cd mineflayer-collectblock
+npm install
 npx tsc
 cd ..
 npm install


### PR DESCRIPTION
Add additional installation step to readme to fix version missmatch fixes #120

According to @Vance0124:
This is due to a version issue with prismarine-block (try npm show prismarine-block, It will display 1.17.1 or some other version but should be 1.16.3 ).