### PR TITLE
Bump `prismarine-block` to 1.17.1

### DIFF
--- a/voyager/env/mineflayer/package.json
+++ b/voyager/env/mineflayer/package.json
@@ -22,7 +22,7 @@
         "mineflayer-tool": "^1.2.0",
         "mocha": "^10.2.0",
         "prismarine-biome": "^1.3.0",
-        "prismarine-block": "=1.16.3",
+        "prismarine-block": "^1.17.1",
         "prismarine-entity": "^2.2.0",
         "prismarine-item": "^1.12.1",
         "prismarine-nbt": "^2.2.1",


### PR DESCRIPTION
Current version no longer compiles `npx tsc` command

Likely due to the error that was fixed here:
https://github.com/PrismarineJS/prismarine-block/commit/06ef318525aa92b57b400e0ee899231a4a737bec